### PR TITLE
Multiple concurrent queries

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,3 +7,6 @@ ignore_missing_imports = True
 
 [mypy-boto3.*]
 ignore_missing_imports = True
+
+[mypy-pytz.*]
+ignore_missing_imports = True

--- a/tap_cloudwatch/client.py
+++ b/tap_cloudwatch/client.py
@@ -29,5 +29,5 @@ class CloudWatchStream(Stream):
             self.config.get("batch_increment_s"),
         )
         for batch in cloudwatch_iter:
-            for record in batch.get("results"):
+            for record in batch:
                 yield {i["field"][1:]: i["value"] for i in record}

--- a/tap_cloudwatch/exception.py
+++ b/tap_cloudwatch/exception.py
@@ -1,3 +1,7 @@
+"""Custom exceptions."""
+
+
 class InvalidQueryException(Exception):
-    "Raised when the input value is less than 18"
+    """Raised when the input query is invalid."""
+
     pass

--- a/tap_cloudwatch/streams.py
+++ b/tap_cloudwatch/streams.py
@@ -23,16 +23,12 @@ class LogStream(CloudWatchStream):
         # | parse @message "[*] *" as loggingType, loggingMessage
         properties.append(
             th.Property(
-                "ptr",
-                th.StringType(),
-                description="The identifier for the log record."
+                "ptr", th.StringType(), description="The identifier for the log record."
             )
         )
         properties.append(
             th.Property(
-                "timestamp",
-                th.DateTimeType(),
-                description="The timestamp of the log."
+                "timestamp", th.DateTimeType(), description="The timestamp of the log."
             )
         )
         for prop in self.config.get("query").split("|")[0].split(","):

--- a/tap_cloudwatch/tests/test_cloudwatch_api.py
+++ b/tap_cloudwatch/tests/test_cloudwatch_api.py
@@ -86,5 +86,7 @@ def test_handle_batch_window():
     )
     stubber.activate()
 
-    output = api.handle_batch_window(query_start, query_end, log_group, in_query)
-    assert response == output
+    query_id = api.start_query(query_start, query_end, log_group, in_query)
+    output = api.get_results(log_group, query_start, query_end, in_query, query_id)
+        
+    assert response["results"] == output

--- a/tap_cloudwatch/tests/test_cloudwatch_api.py
+++ b/tap_cloudwatch/tests/test_cloudwatch_api.py
@@ -1,37 +1,43 @@
 """Tests cloudwatch api module."""
 
-from tap_cloudwatch.cloudwatch_api import CloudwatchAPI
-from tap_cloudwatch.exception import InvalidQueryException
-import pytest
-from unittest.mock import patch
-from datetime import datetime, timezone
-
-import boto3
-from botocore.stub import Stubber
-from freezegun import freeze_time
 import logging
 from contextlib import nullcontext as does_not_raise
 
+import boto3
+import pytest
+from botocore.stub import Stubber
+from freezegun import freeze_time
+
+from tap_cloudwatch.cloudwatch_api import CloudwatchAPI
+from tap_cloudwatch.exception import InvalidQueryException
+
 
 @pytest.mark.parametrize(
-    'start,end,batch,expected',
+    "start,end,batch,expected",
     [
         [1672272000, 1672275600, 3600, [(1672272000, 1672275600)]],
-        [1672272000, 1672275601, 3600, [(1672272000, 1672275600), (1672275601, 1672279200)]],
+        [
+            1672272000,
+            1672275601,
+            3600,
+            [(1672272000, 1672275600), (1672275601, 1672279200)],
+        ],
     ],
 )
 def test_split_batch_into_windows(start, end, batch, expected):
     """Run standard tap tests from the SDK."""
     api = CloudwatchAPI(None)
-    batches = api.split_batch_into_windows(start, end, batch)
+    batches = api._split_batch_into_windows(start, end, batch)
     assert batches == expected
 
 
-
 @pytest.mark.parametrize(
-    'query,expectation',
+    "query,expectation",
     [
-        ["fields @timestamp, @message | sort @timestamp desc", pytest.raises(InvalidQueryException)],
+        [
+            "fields @timestamp, @message | sort @timestamp desc",
+            pytest.raises(InvalidQueryException),
+        ],
         ["fields @timestamp, @message | limit 5", pytest.raises(InvalidQueryException)],
         ["stats count(*) by duration as time", pytest.raises(InvalidQueryException)],
         ["fields @message", pytest.raises(InvalidQueryException)],
@@ -42,7 +48,8 @@ def test_validate_query(query, expectation):
     """Run standard tap tests from the SDK."""
     api = CloudwatchAPI(None)
     with expectation:
-        api.validate_query(query)
+        api._validate_query(query)
+
 
 @freeze_time("2022-12-30")
 def test_handle_batch_window():
@@ -66,7 +73,7 @@ def test_handle_batch_window():
             ]
         ],
         "ResponseMetadata": {"HTTPStatusCode": 200},
-        "statistics": {"recordsMatched": 10000}
+        "statistics": {"recordsMatched": 10000},
     }
     stubber.add_response(
         "start_query",
@@ -86,7 +93,7 @@ def test_handle_batch_window():
     )
     stubber.activate()
 
-    query_id = api.start_query(query_start, query_end, log_group, in_query)
-    output = api.get_results(log_group, query_start, query_end, in_query, query_id)
-        
+    query_id = api._start_query(query_start, query_end, log_group, in_query)
+    output = api._get_results(log_group, query_start, query_end, in_query, query_id)
+
     assert response["results"] == output

--- a/tap_cloudwatch/tests/test_core.py
+++ b/tap_cloudwatch/tests/test_core.py
@@ -15,7 +15,7 @@ SAMPLE_CONFIG = {
     "query": "fields @timestamp, @message",
     "aws_region_name": "us-east-1",
     "start_date": "2022-12-29",
-    "batch_increment_s": 86400
+    "batch_increment_s": 86400,
 }
 
 client = boto3.client("logs", region_name="us-east-1")
@@ -49,7 +49,7 @@ def test_standard_tap_tests(patch_client):
                 ]
             ],
             "ResponseMetadata": {"HTTPStatusCode": 200},
-            "statistics": {"recordsMatched": 0}
+            "statistics": {"recordsMatched": 0},
         },
         {"queryId": "123"},
     )


### PR DESCRIPTION
- split query and retrieve results functions up so we can query many at once and retrieve results serially
- improves speed 70% on my test
- I still want to retrieve results in order to keep state correct. If we used threading then it would go faster but the order wouldnt be guaranteed so a state message might go out before all previous batches were done. Also we could have threads retrieve results and have them waiting in memory when the next batch is requested serially but then that adds memory pressure so I have it wait to requests the results.

I noticed that my data is high volume for a few short spurts so the limit exceeded loop takes a toll especially if having to call it multiple times and wait. We can speed that up by eagerly further splitting the query to avoid several serial splits.